### PR TITLE
Make parallelism used in eval_matrix configurable

### DIFF
--- a/lib/EvalHelper.pm
+++ b/lib/EvalHelper.pm
@@ -164,7 +164,8 @@ sub ProcessGto {
     $evalCon->AddGeoToMatrix($geo);
     $evalCon->CloseMatrix();
     # Evaluate the consistency.
-    my $rc = system('eval_matrix', '-q', $evalCon->predictors, $workDir, $workDir);
+    my $par = $options{parallel} // 16;
+    my $rc = system('eval_matrix', "-p", $par, '-q', $evalCon->predictors, $workDir, $workDir);
     if ($rc) {
         die "EvalCon returned error code $rc.";
     }

--- a/scripts/eval_matrix.py
+++ b/scripts/eval_matrix.py
@@ -61,6 +61,7 @@ parser.add_argument("-c", "--classifier", dest="clfType", default="RandomForestC
 parser.add_argument("--LDA", action="store_true",
                   help="Use Linear Discriminant Analysis")
 parser.add_argument("-q", "--quiet", action="store_true", help="suppress status output")
+parser.add_argument("-p", "--parallel", type=int, help="number of processes to use", default=16)
 args = parser.parse_args()
 q = args.quiet;
 if __name__ == '__main__':
@@ -86,7 +87,7 @@ if len(genomes.shape) != 2:
 
 if __name__ == '__main__':
 
-    predictions = joblib.Parallel(n_jobs=32)(joblib.delayed(run_predictor)(n_col) for n_col in range(X_all.shape[1]))
+    predictions = joblib.Parallel(n_jobs=args.parallel)(joblib.delayed(run_predictor)(n_col) for n_col in range(X_all.shape[1]))
 
     predictions = np.asarray(predictions)
     predictions = np.transpose(predictions)

--- a/scripts/p3x-eval-gto.pl
+++ b/scripts/p3x-eval-gto.pl
@@ -64,6 +64,7 @@ my $opt = P3Utils::script_opts('gtoFile outFile outHtml',
         ['template=s', 'template for web pages', { default => "$FIG_Config::mod_base/RASTtk/lib/BinningReports/webdetails.tt" }],
         ['external', 'the genome is not currently installed in PATRIC'],
         ['binned', 'the genome contig IDs are user-suppled, not PATRIC-generated'],
+        ['parallel=i', 'parallelism to use in matrix evaluation', { default => 8 }],
         );
 # Get access to PATRIC.
 my $p3 = P3DataAPI->new();
@@ -83,6 +84,7 @@ if (! $gto) {
 }
 # Call the main processor.
 my $geo = EvalHelper::ProcessGto($gto, 'ref' => $opt->ref, deep => $opt->deep, checkDir => $opt->checkdir, predictors => $opt->predictors,
+    parallel => $opt->parallel,
     p3 => $p3, outFile => $outFile, outHtml => $outHtml, template => $opt->template, external => $opt->external, binned => $opt->binned);
 # Write the results.
 $gto->destroy_to_file($gtoFile);


### PR DESCRIPTION
Default to 8 for p3x-eval-gto (for use in a production environment with possibly multiple instances running) and to 16 otherwise (some quick tests showed performance not being much or at all faster with 32 than 16).

Add option in EvalHelper, and command line option in p3x-eval-gto. 